### PR TITLE
docs: update README and ARCHITECTURE to reflect current M3 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,12 +512,13 @@ deploy/helm/
 - **Purpose**: Main API gateway
 - **Tech Stack**: FastAPI, Python 3.11
 - **Responsibilities**:
-  - Request routing
+  - Request routing to Payments service
+  - Rate limiting (Redis-backed, 60 req/min per tenant)
   - Authentication (future)
-  - Rate limiting (future)
 - **Endpoints**:
   - `GET /healthz` - Health check
-  - More endpoints coming in M1
+  - `POST /pay` - Create payment (proxied to Payments service)
+  - `GET /metrics` - Prometheus metrics
 
 #### Payments Service (`services/payments/`)
 
@@ -530,6 +531,7 @@ deploy/helm/
   - `GET /healthz` - Health check
   - `POST /process` - Process payment
   - `GET /payments/{id}` - Get payment by ID
+  - `GET /metrics` - Prometheus metrics
 
 #### Networking Layer
 
@@ -905,16 +907,30 @@ open htmlcov/index.html
 
 ### Writing Tests
 
-**Unit Test Example:**
+**Unit Test Example (service-level, no external dependencies):**
 
 ```python
-# tests/test_sanity.py
-def test_sanity():
-    """Basic sanity check."""
-    assert 1 + 1 == 2
+# services/payments/tests/test_main.py
+import pytest
+from fastapi.testclient import TestClient
+from ..main import app
+
+client = TestClient(app)
+
+@pytest.mark.unit
+def test_process_payment():
+    response = client.post("/process", json={"amount": 10.0, "currency": "USD"})
+    assert response.status_code == 201
+    assert response.json()["status"] == "completed"
+
+@pytest.mark.unit
+def test_get_payment_not_found():
+    response = client.get("/payments/nonexistent-id")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "payment not found"
 ```
 
-**Integration Test Example:**
+**Integration Test Example (requires running services):**
 
 ```python
 # tests/test_integration.py
@@ -924,7 +940,6 @@ import requests
 pytestmark = pytest.mark.integration
 
 def test_payment_endpoint():
-    """Test payment processing."""
     response = requests.post(
         "http://localhost:8001/process",
         json={"amount": 100, "currency": "USD"}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Resilience Lab - System Architecture**
 
-*Last updated: November 18, 2025*
+*Last updated: 2026-06-06*
 
 ---
 
@@ -141,12 +141,14 @@ Resilience Lab is built as a **microservices architecture** designed for cloud-n
 **Key Features**:
 - Health checks: `GET /healthz`
 - OpenAPI docs: `GET /docs`
-- Future: Authentication, rate limiting
+- Payment proxy: `POST /pay` → forwards to Payments service
+- Metrics: `GET /metrics` (Prometheus)
+- Rate limiting: Redis-backed, 60 req/min per tenant (`X-Tenant` header)
+- Future: Authentication (JWT/OAuth2)
 
 **Configuration**:
 - Port: 8000
-- Database: PostgreSQL (shared)
-- Cache: Redis (shared)
+- Cache: Redis (rate limiting)
 
 ---
 
@@ -188,9 +190,11 @@ Resilience Lab is built as a **microservices architecture** designed for cloud-n
 
 **Key Features**:
 - `POST /process` - Process payment
-- `GET /payments/{id}` - Get payment details
+- `GET /payments/{id}` - Get payment details (404 via `HTTPException` when not found)
 - `GET /healthz` - Health check
-- Validation: Amount > 0, Currency format
+- `GET /metrics` - Prometheus metrics
+- Validation: Amount > 0, ISO 4217 currency code
+- Fault injection: `FAIL_MODE` (500 errors), `SLOW_MODE` (2 s delay) via env vars
 
 **Configuration**:
 - Port: 8001


### PR DESCRIPTION
## Summary

- Updated API Service docs: added `POST /pay`, `GET /metrics`, marked rate limiting as implemented (Redis-backed, 60 req/min per tenant)
- Updated Payments Service docs: added `GET /metrics`, clarified 404 uses `HTTPException`, documented fault injection env vars
- Replaced trivial `assert 1+1==2` test example with real service-level unit tests from `services/payments/tests/`
- Updated ARCHITECTURE.md date and removed stale PostgreSQL reference from API config