### PR TITLE
fix(security): patch openssl CVE-2026-45447 in Docker images

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -3,6 +3,9 @@
 
 FROM python:3.11-slim
 
+# Security: patch OS packages to pick up fixes for newly disclosed CVEs (e.g. openssl/libssl3t64)
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # Security: Create non-root user
 RUN groupadd -r appuser && useradd -r -g appuser appuser
 

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -3,6 +3,9 @@
 
 FROM python:3.11-slim
 
+# Security: patch OS packages to pick up fixes for newly disclosed CVEs (e.g. openssl/libssl3t64)
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # Security: Create non-root user
 RUN groupadd -r appuser && useradd -r -g appuser appuser
 


### PR DESCRIPTION
## Summary
- Trivy started failing CI on `develop`/`main` due to a newly disclosed HIGH CVE (CVE-2026-45447) in `libssl3t64`/`openssl` 3.5.6-1~deb13u1 on the `python:3.11-slim` (Debian 13) base image.
- Add `apt-get update && apt-get upgrade -y` to both `services/api/Dockerfile` and `services/payments/Dockerfile` to pull in the patched `3.5.6-1~deb13u2` packages.