### PR TITLE
fix(security): patch openssl CVE-2026-45447 in Docker images

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -3,6 +3,9 @@
 
 FROM python:3.11-slim
 
+# Security: patch OS packages to pick up fixes for newly disclosed CVEs (e.g. openssl/libssl3t64)
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # Security: Create non-root user
 RUN groupadd -r appuser && useradd -r -g appuser appuser
 

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -3,6 +3,9 @@
 
 FROM python:3.11-slim
 
+# Security: patch OS packages to pick up fixes for newly disclosed CVEs (e.g. openssl/libssl3t64)
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # Security: Create non-root user
 RUN groupadd -r appuser && useradd -r -g appuser appuser
 


### PR DESCRIPTION
## Summary
- Sync main with develop: bring in the openssl/libssl3t64 CVE-2026-45447 fix from PR #68 (apt-get upgrade in API/Payments Dockerfiles).
