### PR TITLE
fix(deploy): point values-dev.yaml payments image at local minikube build

### DIFF
--- a/deploy/helm/values-dev.yaml
+++ b/deploy/helm/values-dev.yaml
@@ -15,7 +15,9 @@ api:
 payments:
   replicaCount: 1
   image:
-    tag: dev
+    repository: resilience-lab-payments
+    tag: local
+    pullPolicy: IfNotPresent
   env:
     - name: LOG_LEVEL
       value: DEBUG


### PR DESCRIPTION
## Summary
- `values-dev.yaml` referenced `ghcr.io/lotoos0/resilience-lab-payments:dev`, which doesn't exist on GHCR
- A `FAIL_MODE=1` rolling update therefore got stuck in `ImagePullBackOff` while the old pod kept serving traffic, silently no-oping fault injection
- Switch `payments.image` to the local minikube build (`repository: resilience-lab-payments`, `tag: local`, `pullPolicy: IfNotPresent`), matching the chart default and the documented minikube workflow (`docs/runbooks/TROUBLESHOOTING_MINIKUBE_IMAGES.md`)

Closes #70
