### PR TITLE
fix(api): correct return type annotation for GET / (closes #63)

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -93,7 +93,7 @@ async def create_payment(payment: PaymentRequest) -> Dict[str, Any]:
 
 
 @app.get("/")
-async def root() -> Dict[str, str]:
+async def root() -> Dict[str, Any]:
     """Root endpoint."""
     return {
         "service": "resilience-lab-api",

--- a/services/api/tests/test_main.py
+++ b/services/api/tests/test_main.py
@@ -1,9 +1,10 @@
 """Unit tests for the API service entrypoint."""
 
 import pytest
+from unittest.mock import Mock, patch
 from fastapi.testclient import TestClient
 
-from ..main import app
+from ..main import app, redis_client
 
 client = TestClient(app)
 
@@ -19,3 +20,18 @@ def test_healthz():
 def test_metrics_endpoint_available():
     response = client.get("/metrics")
     assert response.status_code == 200
+
+
+@pytest.mark.unit
+def test_root():
+    """`/` is rate-limited like any other endpoint, so mock Redis for the check."""
+    mock_pipeline = Mock()
+    mock_pipeline.execute.return_value = [0, 0, True, True]
+    with patch.object(redis_client, "pipeline", return_value=mock_pipeline):
+        response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "service": "resilience-lab-api",
+        "version": "0.0.1",
+        "endpoints": ["/healthz", "/pay"],
+    }


### PR DESCRIPTION
## Summary
- `GET /` was annotated as `Dict[str, str]` but returns `endpoints` as a `list[str]`, so FastAPI's response validation raised `ResponseValidationError` and the endpoint returned HTTP 500.
- Fixed the annotation to `Dict[str, Any]` to match the actual response body.
- Added a regression test asserting `GET /` returns 200 with the expected JSON body (mocking Redis since `/` is rate-limited like any other endpoint).

Closes #63