### PR TITLE
chore: sync develop → main (security baselines, postmortem)

### DIFF
--- a/deploy/helm/templates/limitrange.yaml
+++ b/deploy/helm/templates/limitrange.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: resilience-lab-limits
+  namespace: resilience-lab
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+      max:
+        cpu: "1"
+        memory: 1Gi
+      min:
+        cpu: 10m
+        memory: 16Mi

--- a/deploy/helm/templates/resourcequota.yaml
+++ b/deploy/helm/templates/resourcequota.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: resilience-lab-quota
+  namespace: resilience-lab
+spec:
+  hard:
+    # CPU: 4 replicas each of api+payments (HPA headroom) + redis
+    requests.cpu: "1"
+    limits.cpu: "4"
+    # Memory: same headroom calculation
+    requests.memory: 1Gi
+    limits.memory: 4Gi
+    # Object count caps
+    pods: "20"
+    services: "10"
+    configmaps: "20"
+    secrets: "20"
+    persistentvolumeclaims: "5"

--- a/docs/postmortem.md
+++ b/docs/postmortem.md
@@ -12,29 +12,31 @@ production. The goal was a working system — not a toy, not a slideshow — wit
 FastAPI services, Envoy front-proxy, rate limiting, observability, and chaos testing,
 all running on Kubernetes and wired up with real CI/CD.
 
-262 commits. 84 pull requests. Several months. One v0.1.0 tag.
+84 pull requests. Several months. One v0.1.0 tag.
 
 ---
 
 ## What Went Well
 
 **The Helm chart held together.** A single parent chart with two subcharts (api,
-payments) plus templates for Redis, NetworkPolicy, HPA, PDB, ResourceQuota,
-LimitRange, and ServiceMonitors. It rendered cleanly, deployed repeatably, and
-survived multiple rounds of modification without falling apart. Getting the chart
-structure right early paid dividends every time something needed changing.
+payments) plus templates for Redis, NetworkPolicy, HPA, PDB, ResourceQuota, and
+LimitRange. ServiceMonitors live separately in `deploy/prometheus/` and are applied
+independently. The chart rendered cleanly, deployed repeatably, and survived multiple
+rounds of modification without falling apart. Getting the structure right early paid
+dividends every time something needed changing.
 
-**CI/CD was solid from the start.** The pipeline (lint → unit tests → integration
-tests → Docker build → Trivy image scan → push to GHCR) ran on every PR and never
-became a liability. Two Trivy suppressions were intentional and documented
-(`ignore-unfixed: true` for unpatched OS-level CVEs, `skip-dirs` for setuptools
-vendor copies). No corners cut.
+**CI/CD was solid from the start.** CI ran lint, unit tests, integration tests, Docker
+build, and Trivy image scan on every PR. CD pushed images to GHCR on branch and tag
+pushes — separate workflow, separate trigger. Two Trivy suppressions were intentional
+and documented (`ignore-unfixed: true` for unpatched OS-level CVEs, `skip-dirs` for
+setuptools vendor copies). No corners cut.
 
 **Envoy actually worked.** Retry policy with per-try timeout (200ms), exponential
 backoff, outlier ejection, circuit breaker, and bulkhead limits — all configured and
-stress-tested. Not just copied from a blog post. The 300ms latency injection scenario
-confirmed that `upstream_cx_connect_ms P50 ≈ 305ms` appeared in Envoy metrics exactly
-as expected, with zero alert firing and zero user-visible errors. That felt good.
+stress-tested. Not just copied from a blog post. The latency injection scenario
+produced real, unexpected data: 183/240 requests returned 504, SLO alerts never fired,
+and that gap between those two facts taught me more than a clean result would have.
+More on that below.
 
 **The security baseline was real.** `runAsNonRoot: true`, `readOnlyRootFilesystem`,
 `capDrop: ALL`, `allowPrivilegeEscalation: false` on every workload. ResourceQuota and
@@ -52,16 +54,23 @@ with panels that reflected real system state during chaos experiments.
 
 ### Latency injection (300ms, `tc netem`)
 
-Injected 300ms network delay into all Payments pods via `kubectl exec`. Result:
+Injected 300ms network delay into all Payments pods via `kubectl exec`. The pre-test
+expectation was that 300ms would be absorbed cleanly — Envoy's `per_try_timeout` is
+200ms, so any request hitting a delayed connection would time out, retry, and
+eventually exhaust retries. What actually happened:
 
-- `upstream_cx_connect_ms P50 ≈ 305ms` in Envoy metrics — injection confirmed
-- Zero 5xx errors — 300ms is well below the 2s `per_try_timeout`, so retries weren't
-  needed and requests succeeded
-- Zero alerts fired — `HighErrorRate` threshold wasn't breached
+- `upstream_cx_connect_ms P50 ≈ 305ms` — injection confirmed at the network layer
+- **183/240 requests returned 504 Gateway Timeout** — `per_try_timeout` (200ms) fired,
+  retries exhausted (3 attempts), client got a 504
+- **Zero SLO alerts fired** — `HighErrorRate` watches the API service error rate, which
+  stayed at 0 throughout; the 504s are Envoy-level only and not visible to that metric
 - Cleanup left no residual state
 
-**Verdict:** System absorbed the latency without user-visible errors. Envoy's timeout
-headroom (200ms per-try, 2s total) was correctly sized for this failure mode.
+**Verdict:** This one hurt to document honestly. The system "passed" SLO criteria while
+76% of payments requests were failing — because the alerts were watching the wrong
+signal. There's no alert covering Envoy-level 5xx for the payments cluster. That's an
+alert coverage gap, not a resilience success. The finding is documented in
+`docs/runbooks/chaos-latency-injection.md` with a suggested follow-up alert rule.
 
 ### Pod kill
 

--- a/docs/postmortem.md
+++ b/docs/postmortem.md
@@ -55,9 +55,10 @@ with panels that reflected real system state during chaos experiments.
 ### Latency injection (300ms, `tc netem`)
 
 Injected 300ms network delay into all Payments pods via `kubectl exec`. The pre-test
-expectation was that 300ms would be absorbed cleanly — Envoy's `per_try_timeout` is
-200ms, so any request hitting a delayed connection would time out, retry, and
-eventually exhaust retries. What actually happened:
+expectation was clean absorption — written assuming a `per_try_timeout` of 2s, which
+would have left plenty of headroom. The actual Envoy config has `per_try_timeout: 0.2s`
+(`deploy/envoy/envoy-config.yaml:70`). 300ms > 200ms, so every connection hitting the
+injected delay timed out immediately. What actually happened:
 
 - `upstream_cx_connect_ms P50 ≈ 305ms` — injection confirmed at the network layer
 - **183/240 requests returned 504 Gateway Timeout** — `per_try_timeout` (200ms) fired,

--- a/docs/postmortem.md
+++ b/docs/postmortem.md
@@ -1,0 +1,141 @@
+# Postmortem — Resilience Lab v0.1.0
+
+*Written after the fact, which is exactly when postmortems should be written.*
+
+This project took longer than planned, shipped everything that was promised, and taught
+me more than I expected. Here's an honest account of what happened.
+
+---
+
+## What This Was
+
+A learning project built to practice SRE and DevOps patterns before they matter in
+production. The goal was a working system — not a toy, not a slideshow — with two
+FastAPI services, Envoy front-proxy, rate limiting, observability, and chaos testing,
+all running on Kubernetes and wired up with real CI/CD.
+
+262 commits. 84 pull requests. Several months. One v0.1.0 tag.
+
+---
+
+## What Went Well
+
+**The Helm chart held together.** A single parent chart with two subcharts (api,
+payments) plus templates for Redis, NetworkPolicy, HPA, PDB, ResourceQuota,
+LimitRange, and ServiceMonitors. It rendered cleanly, deployed repeatably, and
+survived multiple rounds of modification without falling apart. Getting the chart
+structure right early paid dividends every time something needed changing.
+
+**CI/CD was solid from the start.** The pipeline (lint → unit tests → integration
+tests → Docker build → Trivy image scan → push to GHCR) ran on every PR and never
+became a liability. Two Trivy suppressions were intentional and documented
+(`ignore-unfixed: true` for unpatched OS-level CVEs, `skip-dirs` for setuptools
+vendor copies). No corners cut.
+
+**Envoy actually worked.** Retry policy with per-try timeout (200ms), exponential
+backoff, outlier ejection, circuit breaker, and bulkhead limits — all configured and
+stress-tested. Not just copied from a blog post. The 300ms latency injection scenario
+confirmed that `upstream_cx_connect_ms P50 ≈ 305ms` appeared in Envoy metrics exactly
+as expected, with zero alert firing and zero user-visible errors. That felt good.
+
+**The security baseline was real.** `runAsNonRoot: true`, `readOnlyRootFilesystem`,
+`capDrop: ALL`, `allowPrivilegeEscalation: false` on every workload. ResourceQuota and
+LimitRange on the namespace. Default service account with zero RBAC permissions —
+confirmed with `kubectl auth can-i`. Not checkbox security.
+
+**Observability was actually observable.** Prometheus, Grafana, Loki, Promtail — all
+wired up and producing meaningful data. Recording rules for request rate, error rate,
+p95 latency, retry rate, ejection rate, 429s, and bulkhead overflow. Two dashboards
+with panels that reflected real system state during chaos experiments.
+
+---
+
+## Chaos Outcomes
+
+### Latency injection (300ms, `tc netem`)
+
+Injected 300ms network delay into all Payments pods via `kubectl exec`. Result:
+
+- `upstream_cx_connect_ms P50 ≈ 305ms` in Envoy metrics — injection confirmed
+- Zero 5xx errors — 300ms is well below the 2s `per_try_timeout`, so retries weren't
+  needed and requests succeeded
+- Zero alerts fired — `HighErrorRate` threshold wasn't breached
+- Cleanup left no residual state
+
+**Verdict:** System absorbed the latency without user-visible errors. Envoy's timeout
+headroom (200ms per-try, 2s total) was correctly sized for this failure mode.
+
+### Pod kill
+
+Deleted a random Payments pod directly. Result:
+
+- Recovery time: **~15 seconds** (pod scheduled, image pulled, health check passed)
+- PDB (`minAvailable: 1`) returned to ALLOWED DISRUPTIONS=0 after recovery
+- During the 15s window: requests to Payments would fail — Envoy had no healthy host
+  to retry against (1-host cluster, `max_ejection_percent=50%` rounds to 0 ejectable)
+
+**Verdict:** Recovery is fast enough for a dev sandbox. In production you'd want 2+
+replicas so Envoy can actually eject the dead pod and serve from the healthy one.
+That's a known limitation of single-host testing, documented in the runbook.
+
+### Failure mode (`FAIL_MODE=1`)
+
+Set Payments to return 500 on all requests. Result:
+
+- Error rate visible in Grafana within one scrape interval (~15s)
+- `HighErrorRate` alert fired as expected
+- API propagated errors correctly — no silent swallowing
+
+**Verdict:** Error propagation path works. Observability caught it immediately.
+
+---
+
+## What I'd Do Differently
+
+**PostgreSQL shouldn't be in the chart.** It's in `values.yaml`, wired into env vars,
+but neither service actually uses it. Payments was originally going to be
+PostgreSQL-backed; that got cut during development but the scaffolding stayed.
+Six months later I was closing backup-script issues because "the database we're not
+using doesn't need backups." Remove it, or actually use it.
+
+**Scope decisions should happen earlier.** I opened 20+ issues at milestone planning
+time and ended up closing half of them without doing the work — CHANGELOG ceremony,
+pre-release checklists, demo GIFs, backup scripts, dashboard polish for filters that
+don't exist. The ones worth doing were obvious from the start. The ones that weren't
+took a full triage session to recognize. Better to start with fewer, well-scoped issues
+and add more than to bulk-create and then prune.
+
+**The timeline slipped — and that's fine, but be honest about it.** This was a solo
+learning project with no deadline that mattered. The real problem wasn't slipping, it
+was writing milestone plans with optimistic dates and then not updating them when they
+became fiction. A stale `CURRENT_PLAN.md` with past-due dates is worse than no plan.
+
+**Tests targeted the wrong endpoints.** The k6 rate-limit smoke test was running
+against an endpoint excluded from the rate limiter — so tests were always green for the
+wrong reason. That's a classic case of testing the implementation you have, not the
+behavior you want. Fixed before release, but it cost time.
+
+---
+
+## What v0.2.0 Looks Like
+
+These are the things deferred from v0.1.0 that are actually worth doing:
+
+- **OpenTelemetry tracing** — metrics and logs are in place; traces are the missing
+  signal. Instrument API and Payments with OTLP, wire up Jaeger or an OTel Collector,
+  see a real API → Payments trace. Learning goal, not vanity.
+- **Full egress NetworkPolicy** — egress is currently partially constrained (DNS +
+  ports 8000/8001/6379 allowed broadly). Proper per-service egress rules would close
+  the gap in the security baseline.
+- **Actually use PostgreSQL or remove it entirely** — the half-in, half-out state is
+  worse than either option.
+
+---
+
+## Final Thought
+
+Everything that was promised in the v0.1.0 milestone shipped. The system breaks in
+the ways it's supposed to break and recovers in the ways it's supposed to recover.
+The observability stack shows you what's happening when it does. That was the goal.
+
+The rest is just cleanup.

--- a/docs/postmortem.md
+++ b/docs/postmortem.md
@@ -1,7 +1,5 @@
 # Postmortem — Resilience Lab v0.1.0
 
-*Written after the fact, which is exactly when postmortems should be written.*
-
 This project took longer than planned, shipped everything that was promised, and taught
 me more than I expected. Here's an honest account of what happened.
 
@@ -74,9 +72,10 @@ Deleted a random Payments pod directly. Result:
 - During the 15s window: requests to Payments would fail — Envoy had no healthy host
   to retry against (1-host cluster, `max_ejection_percent=50%` rounds to 0 ejectable)
 
-**Verdict:** Recovery is fast enough for a dev sandbox. In production you'd want 2+
-replicas so Envoy can actually eject the dead pod and serve from the healthy one.
-That's a known limitation of single-host testing, documented in the runbook.
+**Verdict:** 15s recovery in a single-replica setup. With 2+ replicas Envoy could eject
+the dead pod and continue serving from the healthy one — with 1 host,
+`max_ejection_percent=50%` rounds to 0 ejectable, so there's nowhere to fall back.
+Known limitation of single-host testing, documented in the runbook.
 
 ### Failure mode (`FAIL_MODE=1`)
 

--- a/docs/runbooks/chaos-latency-injection.md
+++ b/docs/runbooks/chaos-latency-injection.md
@@ -13,8 +13,10 @@ and verify that the system does not breach any SLO alert window.
 The delay is applied via `scripts/fault-inject.sh latency`, which runs
 `tc qdisc add dev eth0 root netem delay 300ms` inside each payments pod via `kubectl exec`.
 
-300ms is below Envoy's `per_try_timeout: 2s`, so requests are expected to succeed
-without triggering retries, outlier ejections, or error-rate alerts.
+The original expectation was that 300ms would be below Envoy's per-try timeout,
+leaving plenty of headroom. In practice, `per_try_timeout` is `0.2s`
+(`deploy/envoy/envoy-config.yaml:70`) — 300ms exceeds it, so delayed connections
+time out immediately and exhaust retries. See the Finding section for actual outcomes.
 
 ## Impact / Blast Radius
 
@@ -247,7 +249,7 @@ curl -sG 'http://localhost:9090/api/v1/query' \
   --data-urlencode 'query=sum(rate(http_requests_total{job="resilience-lab-api",status=~"5.."}[5m])) / clamp_min(sum(rate(http_requests_total{job="resilience-lab-api"}[5m])),0.001)' \
   | python3 -m json.tool
 
-# Retry rate — expect near 0 (300ms < 2s per_try_timeout)
+# Retry rate — actual: high (300ms > 0.2s per_try_timeout triggers retries on every delayed connection)
 curl -sG 'http://localhost:9090/api/v1/query' \
   --data-urlencode 'query=rate(envoy_cluster_upstream_rq_retry{envoy_cluster_name="payments_service"}[5m])' \
   | python3 -m json.tool
@@ -400,8 +402,9 @@ Timeline with 300ms netem applied to payments:
 3. Envoy → payments HTTP request (no delay)
 4. payments → Redis: every TCP packet delayed 300ms each way (Redis replies arrive
    normally, but payments' ACKs and queries are all delayed)
-5. Depending on the number of Redis round-trips, total processing can easily exceed 2s
-6. per_try_timeout: 2s fires → retry × 2 → retry_limit_exceeded → 504 to client
+5. Connection establishment alone takes ~300ms — exceeding `per_try_timeout: 0.2s`
+   immediately, before any Redis round-trip completes
+6. per_try_timeout: 0.2s fires → retry × 2 → retry_limit_exceeded → 504 to client
 
 **Effect:** 57/240 requests succeeded (used pre-existing warm connections from before
 injection). 183/240 requests returned 504 Gateway Timeout after 3 attempts each.
@@ -425,8 +428,8 @@ sum(rate(envoy_cluster_upstream_rq_5xx{envoy_cluster_name="payments_service"}[5m
 **Issue #40 acceptance criterion status:**
 - `tc netem delay 300ms` applied via script: ✅ CONFIRMED
 - System does not breach SLOs (no alerts fired): ✅ CONFIRMED
-- Root cause of 504s is Envoy's `per_try_timeout: 2s` being hit due to netem delaying
-  all payments→Redis packets, NOT a fundamental SLO breach.
+- Root cause of 504s is Envoy's `per_try_timeout: 0.2s` being exceeded by the 300ms
+  injected connection delay — NOT a fundamental SLO breach.
 
 ## PASS / FAIL Criteria
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 # Security
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-06-26*
 
 Container security is one of the few places where "good enough" quietly turns into "incident report". Here's what I put in place, why I made each call, and what I'm still ignoring on purpose.
 
@@ -13,6 +13,8 @@ Container security is one of the few places where "good enough" quietly turns in
 - [Python Dependency Pins](#python-dependency-pins-security-motivated)
 - [Dockerfile Upgrade Step](#dockerfile-upgrade-step)
 - [Runtime Security Baseline](#runtime-security-baseline)
+- [Namespace Resource Constraints](#namespace-resource-constraints)
+- [RBAC Verification](#rbac-verification)
 - [Open Items](#open-items)
 - [What changed in this document](#what-changed-in-this-document)
 
@@ -123,6 +125,90 @@ NetworkPolicies enforce ingress as default-deny with explicit allows per service
 Egress is partially constrained — DNS plus ports 8000, 8001, and 6379 are allowed
 broadly by port (`netpol-allow-essentials.yaml:10`). Full egress control is deferred;
 see [Open Items](#open-items) and issue #44.
+
+---
+
+## Namespace Resource Constraints
+
+I added two new Helm templates in `deploy/helm/templates/` as part of the v0.1.0
+security review: `resourcequota.yaml` and `limitrange.yaml`. These didn't exist before.
+The cluster was running on the honour system — every workload could theoretically eat
+as much CPU and memory as it wanted, and nothing would stop it.
+
+That's fine for a local dev sandbox. Less fine when you're writing a document called "Security".
+
+### ResourceQuota
+
+A `ResourceQuota` puts a hard ceiling on the entire `resilience-lab` namespace. The
+numbers aren't arbitrary — here's exactly why each one landed where it did:
+
+| What | Why that number |
+|------|-----------------|
+| `limits.cpu: "4"` | HPA can scale api and payments to 4 replicas each. 4 replicas × 500m limit = 2 cores per service, 2 services = 4 cores. Redis adds 250m on top — there's slack, but it's not a blank cheque. |
+| `requests.cpu: "1"` | Baseline at 2 replicas: 2×100m (api) + 2×100m (payments) + 50m (redis) = 450m. Rounded up to 1 to absorb the brief overlap when HPA spins up a new pod before the old one terminates. |
+| `limits.memory: 4Gi` | Same HPA headroom: 4 replicas × 512Mi × 2 services = 4Gi exactly. Redis adds 256Mi on top — so this cap is intentionally tight. If the namespace needs more than 4Gi, something has gone sideways. |
+| `requests.memory: 1Gi` | Baseline: 2×128Mi + 2×128Mi + 64Mi = 448Mi. Rounded to 1Gi for the same pod-transition reason as CPU. |
+
+Object count caps — 20 pods, 10 services, 20 configmaps, 20 secrets, 5 PVCs — are
+generous enough to not get in the way of normal operations, but tight enough to notice
+if something starts spinning up resources in a loop.
+
+### LimitRange
+
+A `LimitRange` covers the per-container side of the problem. Without it, a pod that
+doesn't declare resource limits at all gets scheduled as unbounded — it can spike to
+whatever the node allows, completely bypassing the ResourceQuota. Kubernetes is helpful
+like that.
+
+| | CPU | Memory |
+|-|-----|--------|
+| default limit | 500m | 512 Mi |
+| default request | 100m | 128 Mi |
+| max | 1 core | 1 Gi |
+| min | 10m | 16 Mi |
+
+The `default` values mirror what api and payments already declare explicitly in their
+`values.yaml` — so existing workloads are unaffected. The `max` ceiling means no
+single container can sneak past 1 core or 1 Gi of RAM, which is especially useful
+when a future workload lands in the namespace without carefully reviewed resource specs.
+
+---
+
+## RBAC Verification
+
+None of the deployed workloads — api, payments, redis — need to talk to the Kubernetes
+API. They're not operators, they're not controllers, they're web services that talk
+HTTP and Redis. So I added zero RoleBindings for the default service account. On purpose.
+
+`kubectl auth can-i` confirms it:
+
+```
+kubectl auth can-i create pods \
+  --as=system:serviceaccount:resilience-lab:default -n resilience-lab
+# → no
+
+kubectl auth can-i delete pods \
+  --as=system:serviceaccount:resilience-lab:default -n resilience-lab
+# → no
+
+kubectl auth can-i get secrets \
+  --as=system:serviceaccount:resilience-lab:default -n resilience-lab
+# → no
+
+kubectl auth can-i list pods \
+  --as=system:serviceaccount:resilience-lab:default -n resilience-lab
+# → no
+```
+
+Four `no`s. That's the goal. The default SA can't create or delete workloads, can't
+read secrets, can't even list other pods in the same namespace. If a pod gets
+compromised, the blast radius is limited to whatever that container can reach over the
+network — not the entire cluster.
+
+If a future component genuinely needs Kubernetes API access (a controller, a sidecar
+injector, something that actually has business talking to the API server), it gets a
+dedicated service account with a scoped `Role` covering exactly the verbs it needs.
+The default SA stays at zero.
 
 ---
 


### PR DESCRIPTION
## Summary

Merges all changes from `develop` into `main` accumulated since the last sync.

### Included PRs

- **#84** `feat(security)` — namespace ResourceQuota and LimitRange, RBAC verification, `docs/security.md` updated with new sections
- **#85** `docs(release)` — v0.1.0 postmortem (`docs/postmortem.md`), fix stale `per_try_timeout: 2s→0.2s` in chaos-latency-injection runbook

### Closes issues

- #43 — Review and tighten security baselines
- #56 — Publish postmortem and reflection