### PR TITLE
fix(ci): fail when compose stack is not ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,19 +106,17 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install dependencies
         run: pip install -r requirements.txt
-      - name: Start services with docker compose
-        run: docker compose up -d
-      - name: Wait for services to be healthy
-        run: |
-          timeout 60 bash -c 'until docker compose ps | grep -q "healthy"; do sleep 2; done' || true
-          sleep 10
+      - name: Start services and wait for readiness
+        run: docker compose up -d --wait --wait-timeout 60
       - name: Check services status
         run: docker compose ps
       - name: Run integration tests
         run: pytest -v -m integration
-      - name: Show logs on failure
+      - name: Show diagnostics on failure
         if: failure()
-        run: docker compose logs
+        run: |
+          docker compose ps
+          docker compose logs --no-color
       - name: Stop services
         if: always()
         run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             ${{ runner.os }}-pip-lint-
             ${{ runner.os }}-pip-
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.1.6
       - name: Lint all services
         run: ruff check services/
   trivy-fs:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -413,7 +413,7 @@ trivy-fs (independent, runs in parallel)
 | `lint` | `ruff check services/` |
 | `trivy-fs` | Trivy filesystem scan (CRITICAL + HIGH), results to GitHub Security tab |
 | `test` | Unit tests (`pytest -m "not integration"`) with postgres:16 + redis:7-alpine sidecar containers (mocked by tests), coverage → Codecov |
-| `integration-test` | Spins up the Docker Compose stack, does a shallow health wait plus a 10s settle, runs `pytest -m integration`, tears down |
+| `integration-test` | Spins up the Docker Compose stack, waits for every service healthcheck with a fail-closed timeout, runs `pytest -m integration`, tears down |
 | `build` | Builds both images, runs Trivy image scan (exit-code 1 on CRITICAL/HIGH unfixed CVEs) |
 
 **Note on CI service containers**: The test job spins up postgres:16 and
@@ -424,9 +424,9 @@ a live connection.
 
 **Why integration tests are separate**: They need Docker Compose, which means
 building images. I keep them in their own job so `lint` and `test` can fail fast
-without waiting for Docker. The wait loop I wrote checks for any `healthy`
-container and then sleeps 10s — it's a pragmatic smoke gate I'm comfortable with,
-not a perfect "all services are healthy" oracle. Tiny CI fortune cookie, basically.
+without waiting for Docker. The job uses `docker compose up --wait` to require
+every service healthcheck to pass. If the stack is not ready before the timeout,
+the step fails, diagnostics are printed, and integration tests do not start.
 
 ### CD (`cd.yml`) — push to `main`/`develop`, or `v*` tag
 


### PR DESCRIPTION
## Summary

- replace the shallow `grep "healthy"` readiness loop and fixed sleep with `docker compose up --wait --wait-timeout 60`
- fail the integration job when any required service does not become healthy
- print Compose status and logs on failure while preserving unconditional cleanup
- pin CI to the repository's `ruff==0.1.6` version so local and remote lint use the same ruleset
- update deployment documentation to describe the fail-closed readiness gate

## Root cause

The previous readiness check succeeded when any container reported `healthy`, and `|| true` suppressed readiness timeouts. Integration tests could therefore start without the full stack being ready.

CI also installed an unpinned latest Ruff while the repository pins `ruff==0.1.6`. This made the remote lint result drift from the locally validated repository toolchain.

## Impact

Integration tests now start only after all four required services pass their health checks. A timeout or unhealthy service stops the job before tests run and leaves useful diagnostics. CI lint is deterministic and matches the repository version.

## Validation

Local:

- `git diff --check`
- workflow YAML parse
- `docker compose config --quiet`
- `make lint`
- unit tests: 17 passed, 1 skipped
- integration tests: 4 passed
- positive readiness path: Postgres, Redis, Payments, and API all reached `healthy`
- negative readiness path: forced API health-check failure returned exit code 1; Compose status and logs remained available
- isolated test containers, networks, volumes, and override file removed

GitHub Actions:

- lint: passed
- test: passed
- trivy-fs: passed
- integration-test: passed
- build: passed
- Trivy: passed

Refs #89